### PR TITLE
OneDimTask7が正常に稼働していなかったと思われる問題を解決。

### DIFF
--- a/environment/Assets/Scenes/OneDimTask7.unity
+++ b/environment/Assets/Scenes/OneDimTask7.unity
@@ -203,7 +203,7 @@ Prefab:
     - target: {fileID: 114197114229233650, guid: 7807d5793a14e43459d66a7063f42614,
         type: 2}
       propertyPath: ManualOverride
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7807d5793a14e43459d66a7063f42614, type: 2}


### PR DESCRIPTION
どこかでオペミスをして、一つ必要なCanvasを消してしまっていた、ように見えます。

動作の確認がローカルでは完結しないものですが、エラーは出なくなりました。
