### PR TITLE
Add task finished signal to reset message

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -52,8 +52,9 @@ def unpack_reset(payload):
     success = dat['success']
     failure = dat['failure']
     elapsed = dat['elapsed']
+    finished = dat['finished']
 
-    return reward, success, failure, elapsed
+    return reward, success, failure, elapsed, finished
 
 use_gpu = int(os.getenv('GPU', '-1'))
 depth_image_dim = 32 * 32
@@ -109,7 +110,7 @@ class Root(object):
     @cherrypy.expose
     def reset(self, identifier):
         body = cherrypy.request.body.read()
-        reward, success, failure, elapsed = unpack_reset(body)
+        reward, success, failure, elapsed, finished = unpack_reset(body)
 
         inbound_logger.info('reward: {}, success: {}, failure: {}, elapsed: {}'.format(
             reward, success, failure, elapsed))
@@ -118,7 +119,6 @@ class Root(object):
 
         outbound_logger.info('result: {}'.format(result))
         return str(result)
-
 
 def main(args):
     cherrypy.config.update({'server.socket_host': args.host, 'server.socket_port': args.port, 'log.screen': False,

--- a/environment/Assets/Scripts/AgentBehaviour.cs
+++ b/environment/Assets/Scripts/AgentBehaviour.cs
@@ -29,19 +29,24 @@ public class AgentBehaviour : MonoBehaviour {
         return packer.Pack(msg);
     }
 
-    byte[] GenerateResetMessage() {
+    byte[] GenerateResetMessage(bool finished) {
         ResetMessage msg = new ResetMessage();
 
         msg.reward = PlayerPrefs.GetFloat("Reward");
         msg.success = PlayerPrefs.GetInt("Success Count");
         msg.failure = PlayerPrefs.GetInt("Failure Count");
         msg.elapsed = PlayerPrefs.GetInt("Elapsed Time");
+        msg.finished = finished;
 
         return packer.Pack(msg);
     }
 
     public void Reset() {
-        client.Reset(GenerateResetMessage());
+        client.Reset(GenerateResetMessage(false));
+    }
+
+    public void Finish() {
+        client.Reset(GenerateResetMessage(true));
     }
 
     void Start () {

--- a/environment/Assets/Scripts/Environment.cs
+++ b/environment/Assets/Scripts/Environment.cs
@@ -60,6 +60,8 @@ public class Environment : MonoBehaviour {
             task.Reset();
 
             if(task.Done(successCount, failureCount)) {
+                task.Finish();
+
                 PlayerPrefs.SetInt("Success Count", 0);
                 PlayerPrefs.SetInt("Failure Count", 0);
                 EditorSceneManager.LoadScene(task.Next());

--- a/environment/Assets/Scripts/Message.cs
+++ b/environment/Assets/Scripts/Message.cs
@@ -10,4 +10,5 @@ public class ResetMessage {
     public int success = 0;
     public int failure = 0;
     public int elapsed = 0;
+    public bool finished = false;
 }

--- a/environment/Assets/Scripts/Task.cs
+++ b/environment/Assets/Scripts/Task.cs
@@ -20,6 +20,10 @@ public abstract class Task : MonoBehaviour {
         agent.behaviour.Reset();
     }
 
+    public virtual void Finish() {
+        agent.behaviour.Finish();
+    }
+
     protected virtual void OnRewardCollision() {
         rewardCount += 1;
         Reward.Add(2.0F);


### PR DESCRIPTION
This PR introduces a feature in which a finished flag is sent to the reset handler every time a task is considered *done*.