### PR TITLE
Add manual scene ordering interface

### DIFF
--- a/environment/Assets/Scenes/Startup.unity
+++ b/environment/Assets/Scenes/Startup.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311918, g: 0.3807398, b: 0.35872716, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -137,7 +137,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   RotationSpeed: 10
   MovementSpeed: 2
-  FirstScene: OneDimTask1
+  SceneNames:
+  - OneDimTask1
+  - OneDimTask2
+  - OneDimTask3
+  - OneDimTask4
+  - OneDimTask5
+  - OneDimTask6
+  - OneDimTask7
+  - CrossMazeTask1
+  - CrossMazeTask2
+  - ArrowMazeTask1
+  - ArrowMazeTask2
+  - ArrowMazeTask3
+  ManualOverride: 0
 --- !u!4 &1529978036
 Transform:
   m_ObjectHideFlags: 0

--- a/environment/Assets/Scripts/AgentController.cs
+++ b/environment/Assets/Scripts/AgentController.cs
@@ -5,8 +5,6 @@ public class AgentController : MonoBehaviour {
     float rotationSpeed = 10.0F;
     float movementSpeed = 1.0F;
 
-    public bool ManualOverride = false;
-
     [HideInInspector]
     public bool Paralyzed = false;
 
@@ -25,6 +23,8 @@ public class AgentController : MonoBehaviour {
         CharacterController controller = GetComponent<CharacterController>();
 
         if(Paralyzed) return;
+
+        bool ManualOverride = PlayerPrefs.GetInt("Manual Override") == 1 ? true : false;
 
         if(ManualOverride) {
             if(Input.GetKey(KeyCode.RightArrow)) {

--- a/environment/Assets/Scripts/ArrowMazeTask1.cs
+++ b/environment/Assets/Scripts/ArrowMazeTask1.cs
@@ -5,7 +5,6 @@ public class ArrowMazeTask1 : Task {
 	bool waited = false;
 
 	public override string Name() { return "Arrow Maze Task 1"; }
-	public override string Next() { return "ArrowMazeTask2"; }
 
 	public override void Initialize(int success, int failure) {
 	}

--- a/environment/Assets/Scripts/ArrowMazeTask2.cs
+++ b/environment/Assets/Scripts/ArrowMazeTask2.cs
@@ -5,7 +5,6 @@ public class ArrowMazeTask2 : Task {
 	bool waited = false;
 
 	public override string Name() { return "Arrow Maze Task 2"; }
-	public override string Next() { return "ArrowMazeTask3"; }
 
 	public override void Initialize(int success, int failure) {
 	}

--- a/environment/Assets/Scripts/ArrowMazeTask3.cs
+++ b/environment/Assets/Scripts/ArrowMazeTask3.cs
@@ -5,7 +5,6 @@ public class ArrowMazeTask3 : Task {
 	bool waited = false;
 
 	public override string Name() { return "Arrow Maze Task 3"; }
-	public override string Next() { return "ArrowMazeTask3"; }
 
 	public override void Initialize(int success, int failure) {
 	}

--- a/environment/Assets/Scripts/CrossMazeTask1.cs
+++ b/environment/Assets/Scripts/CrossMazeTask1.cs
@@ -2,7 +2,6 @@
 
 public class CrossMazeTask1 : Task {
 	public override string Name() { return "Cross Maze Task 1"; }
-	public override string Next() { return "CrossMazeTask2"; }
 
 	public override void Initialize(int success, int failure) {
 		// 仕様「S地点は3ヶ所あり、ランダムにスタート地点が決定する」を実現する

--- a/environment/Assets/Scripts/CrossMazeTask2.cs
+++ b/environment/Assets/Scripts/CrossMazeTask2.cs
@@ -2,7 +2,6 @@
 
 public class CrossMazeTask2 : Task {
 	public override string Name() { return "Cross Maze Task 2"; }
-	public override string Next() { return "ArrowMazeTask1"; }
 
 	public override void Initialize(int success, int failure) {
 		// 仕様「S地点は中心で、向きはランダム」を実現する

--- a/environment/Assets/Scripts/Environment.cs
+++ b/environment/Assets/Scripts/Environment.cs
@@ -64,7 +64,7 @@ public class Environment : MonoBehaviour {
 
                 PlayerPrefs.SetInt("Success Count", 0);
                 PlayerPrefs.SetInt("Failure Count", 0);
-                EditorSceneManager.LoadScene(task.Next());
+                EditorSceneManager.LoadScene(Scenes.Next());
                 return;
             }
 

--- a/environment/Assets/Scripts/OneDimTask1.cs
+++ b/environment/Assets/Scripts/OneDimTask1.cs
@@ -2,7 +2,6 @@
 
 public class OneDimTask1 : Task {
     public override string Name() { return "One Dimensional Task 1"; }
-    public override string Next() { return "OneDimTask2"; }
 
     public override void Initialize(int success, int failure) {
         float z = (float)(22 - (success - failure));

--- a/environment/Assets/Scripts/OneDimTask2.cs
+++ b/environment/Assets/Scripts/OneDimTask2.cs
@@ -6,7 +6,6 @@ public class OneDimTask2 : Task {
     bool rewardShown = false;
 
     public override string Name() { return "One Dimensional Task 2"; }
-    public override string Next() { return "OneDimTask3"; }
 
     public override bool Success() {
         return rewardCount > 1;

--- a/environment/Assets/Scripts/OneDimTask3.cs
+++ b/environment/Assets/Scripts/OneDimTask3.cs
@@ -9,7 +9,6 @@ public class OneDimTask3 : Task {
     Range range = Range.Green;
 
     public override string Name() { return "One Dimensional Task 3"; }
-    public override string Next() { return "OneDimTask4"; }
 
     public override bool Success() {
         return rewardCount > 1;

--- a/environment/Assets/Scripts/OneDimTask4.cs
+++ b/environment/Assets/Scripts/OneDimTask4.cs
@@ -9,7 +9,6 @@ public class OneDimTask4 : Task {
     Range range = Range.Red;
 
     public override string Name() { return "One Dimensional Task 4"; }
-    public override string Next() { return "OneDimTask5"; }
 
     public override bool Success() {
         return rewardCount > 1;

--- a/environment/Assets/Scripts/OneDimTask5.cs
+++ b/environment/Assets/Scripts/OneDimTask5.cs
@@ -9,7 +9,6 @@ public class OneDimTask5 : Task {
     Range range = Range.Blue;
 
     public override string Name() { return "One Dimensional Task 5"; }
-    public override string Next() { return "OneDimTask6"; }
 
     public override bool Success() {
         return rewardCount > 1;

--- a/environment/Assets/Scripts/OneDimTask6.cs
+++ b/environment/Assets/Scripts/OneDimTask6.cs
@@ -9,7 +9,6 @@ public class OneDimTask6 : Task {
     Range range;
 
     public override string Name() { return "One Dimensional Task 6"; }
-    public override string Next() { return "OneDimTask7"; }
 
     public override void Initialize(int success, int failure) {
         switch((success + failure) % 3) {

--- a/environment/Assets/Scripts/OneDimTask7.cs
+++ b/environment/Assets/Scripts/OneDimTask7.cs
@@ -11,7 +11,6 @@ public class OneDimTask7 : Task {
     Range range;
 
     public override string Name() { return "One Dimensional Task 6"; }
-    public override string Next() { return "CrossMazeTask1"; }
 
     public override void Initialize(int success, int failure) {
         int phase = (int)(Random.value * 3);

--- a/environment/Assets/Scripts/Scenes.cs
+++ b/environment/Assets/Scripts/Scenes.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+
+public class Scenes {
+    public static void Init() {
+        PlayerPrefs.SetInt("Scene Number", 0);
+    }
+
+    public static string First() {
+        return PlayerPrefs.GetString("Scene0");
+    }
+
+    public static string Next() {
+        int nextSceneNumber = PlayerPrefs.GetInt("Scene Number") + 1;
+
+        if(!PlayerPrefs.HasKey("Scene" + nextSceneNumber)) {
+            nextSceneNumber = 0;
+        }
+
+        PlayerPrefs.SetInt("Scene Number", nextSceneNumber);
+
+        return Get(nextSceneNumber);
+    }
+
+    public static string Get(int i) {
+        return PlayerPrefs.GetString("Scene" + i);
+    }
+
+    public static void Set(int i, string value) {
+        PlayerPrefs.SetString("Scene" + i, value);
+    }
+}

--- a/environment/Assets/Scripts/Scenes.cs.meta
+++ b/environment/Assets/Scripts/Scenes.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8e7a795ac09a8498381713906abd58db
+timeCreated: 1502936276
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/environment/Assets/Scripts/Startup.cs
+++ b/environment/Assets/Scripts/Startup.cs
@@ -9,12 +9,38 @@ public class Startup : MonoBehaviour {
     float MovementSpeed;
 
     [SerializeField]
-    string FirstScene = "OneDimTask1";
+    string[] SceneNames = {
+        "OneDimTask1",
+        "OneDimTask2",
+        "OneDimTask3",
+        "OneDimTask4",
+        "OneDimTask5",
+        "OneDimTask6",
+        "OneDimTask7",
+
+        "CrossMazeTask1",
+        "CrossMazeTask2",
+
+        "ArrowMazeTask1",
+        "ArrowMazeTask2",
+        "ArrowMazeTask3"
+    };
+
+    [SerializeField]
+    bool ManualOverride = false;
 
     void Start () {
         PlayerPrefs.DeleteAll();
         PlayerPrefs.SetFloat("Rotation Speed", RotationSpeed);
         PlayerPrefs.SetFloat("Movement Speed", MovementSpeed);
-        EditorSceneManager.LoadScene(FirstScene);
+        PlayerPrefs.SetInt("Manual Override", ManualOverride ? 1 : 0);
+
+        for(int i = 0; i < SceneNames.Length; ++i) {
+            Scenes.Set(i, SceneNames[i]);
+        }
+
+        Scenes.Init();
+
+        EditorSceneManager.LoadScene(Scenes.First());
     }
 }

--- a/environment/Assets/Scripts/Task.cs
+++ b/environment/Assets/Scripts/Task.cs
@@ -6,7 +6,6 @@ public abstract class Task : MonoBehaviour {
     protected int rewardCount = 0;
 
     public abstract string Name();
-    public abstract string Next();
 
     public virtual void Initialize(int success, int failure) {
         return;

--- a/environment/ProjectSettings/ProjectVersion.txt
+++ b/environment/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.1.0xf3Linux
+m_EditorVersion: 2017.1.0f3


### PR DESCRIPTION
This PR introduces scene ordering in the Startup scene. The scene order can be specified in the Scene Names attributes within the GameObject registered in the Startup scene.