### PR TITLE
Fix HTTP call to execute in LateUpdate

### DIFF
--- a/environment/Assets/Scripts/AgentBehaviour.cs
+++ b/environment/Assets/Scripts/AgentBehaviour.cs
@@ -54,7 +54,7 @@ public class AgentBehaviour : MonoBehaviour {
         sensor = GetComponent<AgentSensor>();
     }
 	
-    void Update () {
+    void LateUpdate () {
         if(!created) {
             if(!client.Calling) {
                 client.Create(GenerateMessage());


### PR DESCRIPTION
This PR introduces a fix to HTTP calls from potentially being executed before the agent controller is updated by moving these routines into the LateUpdate method. This ensures that the next state is correcly sent to the server per step.